### PR TITLE
Suppress RG "get" errors for initial check

### DIFF
--- a/idem_azurerm/states/azurerm/resource/group.py
+++ b/idem_azurerm/states/azurerm/resource/group.py
@@ -140,7 +140,9 @@ async def present(
 
     group = {}
 
-    group = await hub.exec.azurerm.resource.group.get(ctx, name, **connection_auth)
+    group = await hub.exec.azurerm.resource.group.get(
+        ctx, name, azurerm_log_level="info", **connection_auth
+    )
 
     if "error" not in group:
         ret["changes"] = differ.deep_diff(group.get("tags", {}), tags or {})
@@ -218,7 +220,9 @@ async def absent(hub, ctx, name, connection_auth=None, **kwargs):
 
     group = {}
 
-    group = await hub.exec.azurerm.resource.group.get(ctx, name, **connection_auth)
+    group = await hub.exec.azurerm.resource.group.get(
+        ctx, name, azurerm_log_level="info", **connection_auth
+    )
 
     if "error" in group:
         ret["result"] = True


### PR DESCRIPTION
### What does this PR do?
Since we're not using `check_existence` anymore, we need to log at info level for "get" operations when we're not sure if the RG is there or not.

### Previous Behavior
Throws an error on initial "get", even though we intend on creating the RG (or leaving it absent).

### New Behavior
Initial "get" is now at info log level and will be suppressed by default on the next release of POP (>13)

### Commits signed with GPG?
Yes

Please review [idem-azurerm's Contributing Guide](https://github.com/eitrtechnologies/idem-azurerm/blob/master/.github/CONTRIBUTING.md) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
