### PR TITLE
Return dict on error

### DIFF
--- a/idem_azurerm/exec/azurerm/compute/image.py
+++ b/idem_azurerm/exec/azurerm/compute/image.py
@@ -100,7 +100,9 @@ async def create_or_update(
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     compconn = await hub.exec.azurerm.utils.get_client(ctx, "compute", **kwargs)

--- a/idem_azurerm/exec/azurerm/compute/virtual_machine.py
+++ b/idem_azurerm/exec/azurerm/compute/virtual_machine.py
@@ -335,7 +335,9 @@ async def create_or_update(
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     if not network_interfaces:

--- a/idem_azurerm/exec/azurerm/network/load_balancer.py
+++ b/idem_azurerm/exec/azurerm/network/load_balancer.py
@@ -175,7 +175,9 @@ async def create_or_update(hub, ctx, name, resource_group, **kwargs):
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     netconn = await hub.exec.azurerm.utils.get_client(ctx, "network", **kwargs)

--- a/idem_azurerm/exec/azurerm/network/local_network_gateway.py
+++ b/idem_azurerm/exec/azurerm/network/local_network_gateway.py
@@ -86,7 +86,9 @@ async def create_or_update(
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     netconn = await hub.exec.azurerm.utils.get_client(ctx, "network", **kwargs)

--- a/idem_azurerm/exec/azurerm/network/network_interface.py
+++ b/idem_azurerm/exec/azurerm/network/network_interface.py
@@ -158,7 +158,9 @@ async def create_or_update(
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     netconn = await hub.exec.azurerm.utils.get_client(ctx, "network", **kwargs)

--- a/idem_azurerm/exec/azurerm/network/network_security_group.py
+++ b/idem_azurerm/exec/azurerm/network/network_security_group.py
@@ -273,12 +273,11 @@ async def security_rule_create_or_update(
     for params in exclusive_params:
         # pylint: disable=eval-used
         if not eval(params[0]) and not eval(params[1]):
-            log.error(
-                "Either the {0} or {1} parameter must be provided!".format(
-                    params[0], params[1]
-                )
+            errmsg = "Either the {0} or {1} parameter must be provided!".format(
+                params[0], params[1]
             )
-            return False
+            log.error(errmsg)
+            return {"error": errmsg}
         # pylint: disable=eval-used
         if eval(params[0]):
             # pylint: disable=exec-used
@@ -434,7 +433,9 @@ async def create_or_update(hub, ctx, name, resource_group, **kwargs):
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     netconn = await hub.exec.azurerm.utils.get_client(ctx, "network", **kwargs)

--- a/idem_azurerm/exec/azurerm/network/public_ip_address.py
+++ b/idem_azurerm/exec/azurerm/network/public_ip_address.py
@@ -151,7 +151,9 @@ async def create_or_update(hub, ctx, name, resource_group, **kwargs):
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     netconn = await hub.exec.azurerm.utils.get_client(ctx, "network", **kwargs)

--- a/idem_azurerm/exec/azurerm/network/route.py
+++ b/idem_azurerm/exec/azurerm/network/route.py
@@ -158,7 +158,7 @@ async def filter_rule_create_or_update(
     """
     if not isinstance(communities, list):
         log.error("The communities parameter must be a list of strings!")
-        return False
+        return {"error": "The communities parameter must be a list of strings!"}
 
     if "location" not in kwargs:
         rg_props = await hub.exec.azurerm.resource.group.get(
@@ -167,7 +167,9 @@ async def filter_rule_create_or_update(
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     netconn = await hub.exec.azurerm.utils.get_client(ctx, "network", **kwargs)
@@ -337,7 +339,9 @@ async def filter_create_or_update(hub, ctx, name, resource_group, **kwargs):
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     netconn = await hub.exec.azurerm.utils.get_client(ctx, "network", **kwargs)
@@ -711,7 +715,9 @@ async def table_create_or_update(hub, ctx, name, resource_group, **kwargs):
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     netconn = await hub.exec.azurerm.utils.get_client(ctx, "network", **kwargs)

--- a/idem_azurerm/exec/azurerm/network/virtual_network.py
+++ b/idem_azurerm/exec/azurerm/network/virtual_network.py
@@ -341,12 +341,14 @@ async def create_or_update(hub, ctx, name, address_prefixes, resource_group, **k
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     if not isinstance(address_prefixes, list):
         log.error("Address prefixes must be specified as a list!")
-        return False
+        return {"error": "Address prefixes must be specified as a list!"}
 
     netconn = await hub.exec.azurerm.utils.get_client(ctx, "network", **kwargs)
 

--- a/idem_azurerm/exec/azurerm/network/virtual_network_gateway.py
+++ b/idem_azurerm/exec/azurerm/network/virtual_network_gateway.py
@@ -100,7 +100,9 @@ async def connection_create_or_update(
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     netconn = await hub.exec.azurerm.utils.get_client(ctx, "network", **kwargs)
@@ -109,7 +111,9 @@ async def connection_create_or_update(
     # This endpoint will be where the connection originates.
     if not is_valid_resource_id(virtual_network_gateway):
         log.error("Invalid Resource ID was specified as virtual_network_gateway!")
-        return False
+        return {
+            "error": "Invalid Resource ID was specified as virtual_network_gateway!"
+        }
 
     vnetgw1_parsed_id = parse_resource_id(virtual_network_gateway)
 
@@ -120,7 +124,11 @@ async def connection_create_or_update(
         log.error(
             "Invalid Resource ID was specified as virtual_network_gateway! (%s)", esc
         )
-        return False
+        return {
+            "error": "Invalid Resource ID was specified as virtual_network_gateway! ({0})".format(
+                esc
+            )
+        }
 
     vnetgw1 = await hub.exec.azurerm.network.virtual_network_gateway.get(
         ctx=ctx, name=vnetgw1_name, resource_group=vnetgw1_rg, **kwargs
@@ -128,7 +136,9 @@ async def connection_create_or_update(
 
     if "error" in vnetgw1:
         log.error("Unable to find the resource specified in virtual_network_gateway!")
-        return False
+        return {
+            "error": "Unable to find the resource specified in virtual_network_gateway!"
+        }
 
     virtual_network_gateway = {"id": str(vnetgw1["id"])}
 
@@ -138,7 +148,9 @@ async def connection_create_or_update(
         kwargs["virtual_network_gateway2"]
     ):
         log.error("Invalid Resource ID was specified as virtual_network_gateway2!")
-        return False
+        return {
+            "error": "Invalid Resource ID was specified as virtual_network_gateway2!"
+        }
 
     # Check the Resource ID path of local_network_gateway2
     # We can't guarantee the validity of the object, so we hope you have the path correct...
@@ -146,7 +158,7 @@ async def connection_create_or_update(
         kwargs["local_network_gateway2"]
     ):
         log.error("Invalid Resource ID was specified as local_network_gateway2!")
-        return False
+        return {"error": "Invalid Resource ID was specified as local_network_gateway2!"}
 
     if kwargs.get("virtual_network_gateway2"):
         kwargs["virtual_network_gateway2"] = {
@@ -471,7 +483,9 @@ async def create_or_update(
 
         if "error" in rg_props:
             log.error("Unable to determine location from resource group specified.")
-            return False
+            return {
+                "error": "Unable to determine location from resource group specified."
+            }
         kwargs["location"] = rg_props["location"]
 
     netconn = await hub.exec.azurerm.utils.get_client(ctx, "network", **kwargs)


### PR DESCRIPTION
### What does this PR do?
This PR fixes some scenarios where execution modules return boolean `False` on errors. The state modules generally look for a dict with an "error" key in order to determine failure. I hit a scenario where I needed to pass "location" because it wasn't inferred and ran into a `TypeError` exception because the state was looking for that key.

Note that the `delete` execution modules still return booleans in order to stay in line with the Azure SDK. We could make up a return dict format, but it didn't seem worthwhile. We can revisit this if it becomes a problem.

### What issues does this PR fix or reference?
Fixes:  #80 

### Previous Behavior
Errors in some execution modules would return boolean `False`

### New Behavior
All error returns are dictionaries with an "error" key containing error text.

### Commits signed with GPG?
Yes

Please review [idem-azurerm's Contributing Guide](https://github.com/eitrtechnologies/idem-azurerm/blob/master/.github/CONTRIBUTING.md) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
