### PR TITLE
Fix handling of builtin policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2020-06-16
+
+### Added
+
+### Changed
+
+### Fixed
+
+- [#106](https://github.com/eitrtechnologies/idem-azurerm/pull/106) - Fix assignment of built-in policy definitions.
+
+### Deprecated
+
+### Removed
+
 ## [2.3.1] - 2020-06-16
 
 ### Added
@@ -151,6 +165,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release of execution and state modules from Salt along with some additional functionality ported from
   salt-cloud for virtual machines.
 
+[2.3.2]: https://github.com/eitrtechnologies/idem-azurerm/compare/v2.3.1...v2.3.2
 [2.3.1]: https://github.com/eitrtechnologies/idem-azurerm/compare/v2.3.0...v2.3.1
 [2.3.0]: https://github.com/eitrtechnologies/idem-azurerm/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/eitrtechnologies/idem-azurerm/compare/v2.1.0...v2.2.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ project = "idem-azurerm"
 copyright = "2020, EITR Technologies, LLC"  # pylint: disable=redefined-builtin
 author = "EITR Technologies, LLC"
 version = "2.3"
-release = "2.3.1"
+release = "2.3.2"
 
 # -- General configuration ---------------------------------------------------
 

--- a/idem_azurerm/states/azurerm/resource/policy.py
+++ b/idem_azurerm/states/azurerm/resource/policy.py
@@ -4,7 +4,7 @@ Azure Resource Manager (ARM) Resource Policy State Module
 
 .. versionadded:: 1.0.0
 
-.. versionchanged:: 2.0.0
+.. versionchanged:: 2.3.2, 2.0.0
 
 :maintainer: <devops@eitr.tech>
 :configuration: This module requires Azure Resource Manager credentials to be passed via acct. Note that the
@@ -417,13 +417,14 @@ async def assignment_present(
     definition_name,
     display_name=None,
     description=None,
-    assignment_type=None,
     parameters=None,
     connection_auth=None,
     **kwargs,
 ):
     """
     .. versionadded:: 1.0.0
+
+    .. versionchanged:: 2.3.2
 
     Ensure a security policy assignment exists.
 
@@ -441,9 +442,6 @@ async def assignment_present(
 
     :param description:
         The policy assignment description.
-
-    :param assignment_type:
-        The type of policy assignment.
 
     :param parameters:
         Required dictionary if a parameter is used in the policy rule.
@@ -484,12 +482,6 @@ async def assignment_present(
 
     if "error" not in policy:
         action = "update"
-        if (
-            assignment_type
-            and assignment_type.lower() != policy.get("type", "").lower()
-        ):
-            ret["changes"]["type"] = {"old": policy.get("type"), "new": assignment_type}
-
         if scope.lower() != policy["scope"].lower():
             ret["changes"]["scope"] = {"old": policy["scope"], "new": scope}
 
@@ -530,7 +522,6 @@ async def assignment_present(
                 "name": name,
                 "scope": scope,
                 "definition_name": definition_name,
-                "type": assignment_type,
                 "display_name": display_name,
                 "description": description,
                 "parameters": parameters,
@@ -552,7 +543,6 @@ async def assignment_present(
         name=name,
         scope=scope,
         definition_name=definition_name,
-        type=assignment_type,
         display_name=display_name,
         description=description,
         parameters=parameters,

--- a/idem_azurerm/version.py
+++ b/idem_azurerm/version.py
@@ -1,1 +1,1 @@
-version = "2.3.1"
+version = "2.3.2"


### PR DESCRIPTION
### What does this PR do?
This PR fixes the ability to assign built-in policy definitions. The increment in`azure-mgmt-resource` version from the last release gives us some more functionality that was previously missing.

### Previous Behavior
Unable to assign built-in policies.

### New Behavior
Now we can!

### Commits signed with GPG?
Yes

Please review [idem-azurerm's Contributing Guide](https://github.com/eitrtechnologies/idem-azurerm/blob/master/.github/CONTRIBUTING.md) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
