### PR TITLE
Updated PostgreSQL Functionality

### DIFF
--- a/idem_azurerm/exec/azurerm/postgresql/server.py
+++ b/idem_azurerm/exec/azurerm/postgresql/server.py
@@ -79,13 +79,8 @@ async def create(
 
     :param location: The location the resource resides in.
 
-    :param sku: A dictionary representing the SKU (pricing tier) of the server. Parameters include:
-        - ``name``: The name of the SKU, typically, tier + family + cores, e.g. B_Gen4_1, GP_Gen5_8.
-        - ``tier``: The tier of the particular SKU, e.g. Basic. Possible values include: 'Basic', 'GeneralPurpose',
-            and 'MemoryOptimized'.
-        - ``capacity``: The scale up/out capacity, representing server's compute units.
-        - ``size``: The size code, to be interpreted by resource as appropriate.
-        - ``family``: The family of hardware.
+    :param sku: The name of the SKU (pricing tier) of the server. Typically, the name of the sku is in the form
+        tier_family_cores, e.g. B_Gen4_1, GP_Gen5_8.
 
     :param version: Server version. Possible values include: '9.5', '9.6', '10', '10.0', '10.2', '11'.
 
@@ -115,6 +110,9 @@ async def create(
     """
     result = {}
     postconn = await hub.exec.azurerm.utils.get_client(ctx, "postgresql", **kwargs)
+
+    if not isinstance(sku, dict):
+        sku = {"name": sku}
 
     try:
         propsmodel = await hub.exec.azurerm.utils.create_object_model(
@@ -350,13 +348,8 @@ async def update(
 
     :param resource_group: The name of the resource group. The name is case insensitive.
 
-    :param sku: A dictionary representing the SKU (pricing tier) of the server. Parameters include:
-        - ``name``: The name of the SKU, typically, tier + family + cores, e.g. B_Gen4_1, GP_Gen5_8.
-        - ``tier``: The tier of the particular SKU, e.g. Basic. Possible values include: 'Basic', 'GeneralPurpose',
-            and 'MemoryOptimized'.
-        - ``capacity``: The scale up/out capacity, representing server's compute units.
-        - ``size``: The size code, to be interpreted by resource as appropriate.
-        - ``family``: The family of hardware.
+    :param sku: The name of the SKU (pricing tier) of the server. Typically, the name of the sku is in the form
+        tier_family_cores, e.g. B_Gen4_1, GP_Gen5_8.
 
     :param version: Server version. Possible values include: '9.5', '9.6', '10', '10.0', '10.2', '11'.
 
@@ -383,6 +376,9 @@ async def update(
     """
     result = {}
     postconn = await hub.exec.azurerm.utils.get_client(ctx, "postgresql", **kwargs)
+
+    if not isinstance(sku, dict):
+        sku = {"name": sku}
 
     try:
         paramsmodel = await hub.exec.azurerm.utils.create_object_model(

--- a/idem_azurerm/exec/azurerm/postgresql/server_security_alert_policy.py
+++ b/idem_azurerm/exec/azurerm/postgresql/server_security_alert_policy.py
@@ -75,7 +75,7 @@ async def create_or_update(
         'Enabled', 'Disabled'.
 
     :param disabled_alerts: Specifies an array of alerts that are disabled. Possible values are: 'Sql_Injection',
-        'Sql_Injection_Vulnerability', and 'Access_Anomaly'. It is import to note that the default value of this
+        'Sql_Injection_Vulnerability', and 'Access_Anomaly'. It is important to note that the default value of this
         parameter is [''].
 
     :param email_addresses: Specifies an array of e-mail addresses to which the alert is sent. It is important to note

--- a/idem_azurerm/states/azurerm/postgresql/server_security_alert_policy.py
+++ b/idem_azurerm/states/azurerm/postgresql/server_security_alert_policy.py
@@ -206,14 +206,18 @@ async def present(
             ret["result"] = True
             ret[
                 "comment"
-            ] = "The server security alert policy for the server {0} is already present.".format(name)
+            ] = "The server security alert policy for the server {0} is already present.".format(
+                name
+            )
             return ret
 
         if ctx["test"]:
             ret["result"] = None
             ret[
                 "comment"
-            ] = "The server security alert policy for the server {0} would be updated.".format(name)
+            ] = "The server security alert policy for the server {0} would be updated.".format(
+                name
+            )
             return ret
 
     else:
@@ -240,7 +244,9 @@ async def present(
             ret["changes"]["new"]["retention_days"] = retention_days
 
     if ctx["test"]:
-        ret["comment"] = "The server security alert policy for the server {0} would be created.".format(
+        ret[
+            "comment"
+        ] = "The server security alert policy for the server {0} would be created.".format(
             name
         )
         ret["result"] = None
@@ -265,10 +271,14 @@ async def present(
 
     if "error" not in policy:
         ret["result"] = True
-        ret["comment"] = f"The server security alert policy for the server {name} has been {action}d."
+        ret[
+            "comment"
+        ] = f"The server security alert policy for the server {name} has been {action}d."
         return ret
 
-    ret["comment"] = "Failed to {0} the server security alert policy for the server {1}! ({2})".format(
+    ret[
+        "comment"
+    ] = "Failed to {0} the server security alert policy for the server {1}! ({2})".format(
         action, name, policy.get("error")
     )
     if not ret["result"]:

--- a/idem_azurerm/states/azurerm/postgresql/server_security_alert_policy.py
+++ b/idem_azurerm/states/azurerm/postgresql/server_security_alert_policy.py
@@ -94,7 +94,7 @@ async def present(
         'Enabled', 'Disabled'.
 
     :param disabled_alerts: Specifies an array of alerts that are disabled. Possible values are: 'Sql_Injection',
-        'Sql_Injection_Vulnerability', and 'Access_Anomaly'. It is import to note that the default value of this
+        'Sql_Injection_Vulnerability', and 'Access_Anomaly'. It is important to note that the default value of this
         parameter is [''].
 
     :param email_addresses: Specifies an array of e-mail addresses to which the alert is sent. It is important to note
@@ -206,14 +206,14 @@ async def present(
             ret["result"] = True
             ret[
                 "comment"
-            ] = "Server Security Alert Policy {0} is already present.".format(name)
+            ] = "The server security alert policy for the server {0} is already present.".format(name)
             return ret
 
         if ctx["test"]:
             ret["result"] = None
             ret[
                 "comment"
-            ] = "Server Security Alert Policy {0} would be updated.".format(name)
+            ] = "The server security alert policy for the server {0} would be updated.".format(name)
             return ret
 
     else:
@@ -240,7 +240,7 @@ async def present(
             ret["changes"]["new"]["retention_days"] = retention_days
 
     if ctx["test"]:
-        ret["comment"] = "Server Security Alert Policy {0} would be created.".format(
+        ret["comment"] = "The server security alert policy for the server {0} would be created.".format(
             name
         )
         ret["result"] = None
@@ -265,10 +265,10 @@ async def present(
 
     if "error" not in policy:
         ret["result"] = True
-        ret["comment"] = f"Server Security Alert Policy {name} has been {action}d."
+        ret["comment"] = f"The server security alert policy for the server {name} has been {action}d."
         return ret
 
-    ret["comment"] = "Failed to {0} Server Security Alert Policy {1}! ({2})".format(
+    ret["comment"] = "Failed to {0} the server security alert policy for the server {1}! ({2})".format(
         action, name, policy.get("error")
     )
     if not ret["result"]:


### PR DESCRIPTION
### What does this PR do?
This PR does 2 things:
1. Changes the possible messages returned by the server_security_alert_policy state so that they make more sense.
2. Changes the PostgreSQL server state and exec modules so that for the sku needs to be specified only as a name. This fixes an issue where changes were appearing despite nothing being changed.

### Merge requirements satisfied?
- [X] Docs
- [X] Tests written/updated (written on a separate branch)

### Commits signed with GPG?
Yes