### PR TITLE
Added missing waits and pollers for LROs

### DIFF
--- a/idem_azurerm/exec/azurerm/keyvault/key.py
+++ b/idem_azurerm/exec/azurerm/keyvault/key.py
@@ -168,6 +168,7 @@ async def begin_delete_key(hub, ctx, name, vault_url, **kwargs):
     try:
         key = kconn.begin_delete_key(name=name,)
 
+        key.wait()
         result = _key_as_dict(key.result())
     except (KeyVaultErrorException, ResourceNotFoundError) as exc:
         result = {"error": str(exc)}
@@ -201,6 +202,7 @@ async def begin_recover_deleted_key(hub, ctx, name, vault_url, **kwargs):
     try:
         key = kconn.begin_recover_deleted_key(name=name,)
 
+        key.wait()
         result = _key_as_dict(key.result())
     except (KeyVaultErrorException, HttpResponseError) as exc:
         result = {"error": str(exc)}

--- a/idem_azurerm/exec/azurerm/keyvault/vault.py
+++ b/idem_azurerm/exec/azurerm/keyvault/vault.py
@@ -222,6 +222,7 @@ async def create_or_update(
             vault_name=name, resource_group_name=resource_group, parameters=paramsmodel
         )
 
+        vault.wait()
         result = vault.result().as_dict()
     except CloudError as exc:
         await hub.exec.azurerm.utils.log_cloud_error("keyvault", str(exc), **kwargs)

--- a/idem_azurerm/exec/azurerm/log_analytics/workspace.py
+++ b/idem_azurerm/exec/azurerm/log_analytics/workspace.py
@@ -118,6 +118,7 @@ async def create_or_update(
             parameters=spacemodel,
         )
 
+        workspace.wait()
         result = workspace.result().as_dict()
     except CloudError as exc:
         await hub.exec.azurerm.utils.log_cloud_error("loganalytics", str(exc), **kwargs)

--- a/idem_azurerm/exec/azurerm/managementgroup/operations.py
+++ b/idem_azurerm/exec/azurerm/managementgroup/operations.py
@@ -131,6 +131,7 @@ async def create_or_update(hub, ctx, name, display_name=None, parent=None, **kwa
             group_id=name, create_management_group_request=group_request,
         )
 
+        mgroup.wait()
         result = mgroup.result()
     except ErrorResponseException as exc:
         result = {"error": str(exc)}

--- a/idem_azurerm/exec/azurerm/network/virtual_network_gateway.py
+++ b/idem_azurerm/exec/azurerm/network/virtual_network_gateway.py
@@ -4,6 +4,8 @@ Azure Resource Manager (ARM) Virtual Network Gateway Execution Module
 
 .. versionadded:: 1.0.0
 
+.. versionchanged: 3.0.0
+
 :maintainer: <devops@eitr.tech>
 :configuration: This module requires Azure Resource Manager credentials to be passed as keyword arguments
     to every function or via acct in order to work properly.
@@ -188,9 +190,9 @@ async def connection_create_or_update(
             virtual_network_gateway_connection_name=name,
             parameters=connectionmodel,
         )
+
         connection.wait()
-        connection_result = connection.result()
-        result = connection_result.as_dict()
+        result = connection.result().as_dict()
     except CloudError as exc:
         await hub.exec.azurerm.utils.log_cloud_error("network", str(exc), **kwargs)
         result = {"error": str(exc)}
@@ -445,10 +447,19 @@ async def list_(hub, ctx, resource_group, **kwargs):
 
 
 async def create_or_update(
-    hub, ctx, name, resource_group, virtual_network, ip_configurations, **kwargs
+    hub,
+    ctx,
+    name,
+    resource_group,
+    virtual_network,
+    ip_configurations,
+    polling=True,
+    **kwargs,
 ):
     """
     .. versionadded:: 1.0.0
+
+    .. versionchanged:: 3.0.0
 
     Creates or updates a virtual network gateway in the specified resource group.
 
@@ -467,6 +478,12 @@ async def create_or_update(
           - ``subnet``: Name of an existing subnet inside of which the IP config will reside.
         If the active_active keyword argument is disabled, only one IP configuration dictionary is permitted.
         If the active_active keyword argument is enabled, two IP configuration dictionaries are required.
+
+    :param polling: A boolean flag representing whether a Poller will be used during the creation of the Virtual
+        Network Gateway. If set to True, a Poller will be used by this operation and the module will not return until
+        the Virtual Network Gateway has completed its creation process and has been successfully provisioned. If set to
+        False, the module will return once the Virtual Network Gateway has successfully begun its creation process.
+        Defaults to True.
 
     CLI Example:
 
@@ -532,10 +549,11 @@ async def create_or_update(
             resource_group_name=resource_group,
             virtual_network_gateway_name=name,
             parameters=gatewaymodel,
+            polling=polling,
         )
+
         gateway.wait()
-        gateway_result = gateway.result()
-        result = gateway_result.as_dict()
+        result = gateway.result().as_dict()
     except CloudError as exc:
         await hub.exec.azurerm.utils.log_cloud_error("network", str(exc), **kwargs)
         result = {"error": str(exc)}
@@ -704,8 +722,8 @@ async def reset_vpn_client_shared_key(hub, ctx, name, resource_group, **kwargs):
             resource_group_name=resource_group, virtual_network_gateway_name=name
         )
 
-        reset_result = reset.result()
-        result = reset_result.as_dict()
+        reset.wait()
+        result = reset.result().as_dict()
     except CloudError as exc:
         await hub.exec.azurerm.utils.log_cloud_error("network", str(exc), **kwargs)
         result = {"error": str(exc)}
@@ -889,6 +907,7 @@ async def get_vpn_profile_package_url(hub, ctx, name, resource_group, **kwargs):
             resource_group_name=resource_group, virtual_network_gateway_name=name
         )
 
+        url.wait()
         result = url.result()
     except CloudError as exc:
         await hub.exec.azurerm.utils.log_cloud_error("network", str(exc), **kwargs)
@@ -925,6 +944,7 @@ async def get_bgp_peer_status(hub, ctx, name, resource_group, peer=None, **kwarg
             peer=peer,
         )
 
+        peers.wait()
         peers_result = peers.result().as_dict()
         for bgp_peer in peers_result["value"]:
             result["BGP peer"] = bgp_peer
@@ -1027,6 +1047,7 @@ async def get_advertised_routes(hub, ctx, name, resource_group, peer, **kwargs):
             peer=peer,
         )
 
+        routes.wait()
         routes_result = routes.result().as_dict()
         for route in routes_result["value"]:
             result["route_list"] = route
@@ -1125,8 +1146,8 @@ async def set_vpnclient_ipsec_parameters(
             **kwargs,
         )
 
-        params_result = params.result()
-        result = params_result.as_dict()
+        params.wait()
+        result = params.result().as_dict()
     except CloudError as exc:
         await hub.exec.azurerm.utils.log_cloud_error("network", str(exc), **kwargs)
         result = {"error": str(exc)}
@@ -1157,8 +1178,8 @@ async def get_vpnclient_ipsec_parameters(hub, ctx, name, resource_group, **kwarg
             resource_group_name=resource_group, virtual_network_gateway_name=name
         )
 
-        policy_result = policy.result()
-        result = policy_result.as_dict()
+        policy.wait()
+        result = policy.result().as_dict()
     except CloudError as exc:
         await hub.exec.azurerm.utils.log_cloud_error("network", str(exc), **kwargs)
         result = {"error": str(exc)}

--- a/idem_azurerm/exec/azurerm/redis/operations.py
+++ b/idem_azurerm/exec/azurerm/redis/operations.py
@@ -4,6 +4,8 @@ Azure Resource Manager (ARM) Redis Operations Execution Module
 
 .. versionadded:: 2.0.0
 
+.. versionchanged:: 3.0.0
+
 :maintainer: <devops@eitr.tech>
 :configuration: This module requires Azure Resource Manager credentials to be passed as keyword arguments
     to every function or via acct in order to work properly.
@@ -98,10 +100,13 @@ async def create(
     subnet_id=None,
     static_ip=None,
     zones=None,
+    polling=True,
     **kwargs,
 ):
     """
     .. versionadded:: 2.0.0
+
+    .. versionchanged:: 3.0.0
 
     Create or replace (overwrite/recreate, with potential downtime) an existing Redis cache.
 
@@ -139,6 +144,11 @@ async def create(
 
     :param zones: A list of availability zones denoting where the resource needs to come from.
 
+    :param polling: A boolean flag representing whether a Poller will be used during the creation of the Redis Cache.
+        If set to True, a Poller will be used by this operation and the module will not return until the Redis Cache
+        has completed its creation process and has been successfully provisioned. If set to False, the module will
+        return once the Redis Cache has successfully begun its creation process. Defaults to True.
+
     CLI Example:
 
     .. code-block:: bash
@@ -172,9 +182,13 @@ async def create(
 
     try:
         cache = redconn.redis.create(
-            name=name, resource_group_name=resource_group, parameters=paramsmodel
+            name=name,
+            resource_group_name=resource_group,
+            parameters=paramsmodel,
+            polling=polling,
         )
 
+        cache.wait()
         result = cache.result().as_dict()
     except CloudError as exc:
         await hub.exec.azurerm.utils.log_cloud_error("redis", str(exc), **kwargs)
@@ -265,6 +279,7 @@ async def export_data(
             name=name, resource_group_name=resource_group, parameters=paramsmodel
         )
 
+        cache.wait()
         result = cache.result().as_dict()
     except CloudError as exc:
         await hub.exec.azurerm.utils.log_cloud_error("redis", str(exc), **kwargs)
@@ -382,6 +397,7 @@ async def import_data(
             format=file_format,
         )
 
+        cache.wait()
         result = cache.result().as_dict()
     except CloudError as exc:
         await hub.exec.azurerm.utils.log_cloud_error("redis", str(exc), **kwargs)

--- a/idem_azurerm/exec/azurerm/storage/account.py
+++ b/idem_azurerm/exec/azurerm/storage/account.py
@@ -175,6 +175,7 @@ async def create(
             parameters=accountmodel,
         )
 
+        account.wait()
         result = account.result().as_dict()
     except CloudError as exc:
         await hub.exec.azurerm.utils.log_cloud_error("storage", str(exc), **kwargs)

--- a/idem_azurerm/states/azurerm/network/virtual_network_gateway.py
+++ b/idem_azurerm/states/azurerm/network/virtual_network_gateway.py
@@ -4,6 +4,8 @@ Azure Resource Manager (ARM) Virtual Network Gateway State Module
 
 .. versionadded:: 1.0.0
 
+.. versionchanged:: 3.0.0
+
 :maintainer: <devops@eitr.tech>
 :configuration: This module requires Azure Resource Manager credentials to be passed via acct. Note that the
     authentication parameters are case sensitive.
@@ -575,12 +577,15 @@ async def present(
     active_active=None,
     bgp_settings=None,
     address_prefixes=None,
+    polling=True,
     tags=None,
     connection_auth=None,
     **kwargs,
 ):
     """
     .. versionadded:: 1.0.0
+
+    .. versionchanged:: 3.0.0
 
     Ensure a virtual network gateway exists.
 
@@ -637,6 +642,12 @@ async def present(
     :param address_prefixes:
         A list of CIDR blocks which can be used by subnets within the virtual network. Represents the custom routes
         address space specified by the the customer for virtual network gateway and VpnClient.
+
+    :param polling: A boolean flag representing whether a Poller will be used during the creation of the Virtual
+        Network Gateway. If set to True, a Poller will be used by this operation and the module will not return until
+        the Virtual Network Gateway has completed its creation process and has been successfully provisioned. If set to
+        False, the module will return once the Virtual Network Gateway has successfully begun its creation process.
+        Defaults to True.
 
     :param tags:
         A dictionary of strings can be passed as tag metadata to the virtual network gateway object.
@@ -835,6 +846,7 @@ async def present(
         bgp_settings=bgp_settings,
         active_active=active_active,
         custom_routes={"address_prefixes": address_prefixes},
+        polling=polling,
         **gateway_kwargs,
     )
 

--- a/idem_azurerm/states/azurerm/redis/operations.py
+++ b/idem_azurerm/states/azurerm/redis/operations.py
@@ -74,6 +74,7 @@ async def present(
     subnet_id=None,
     static_ip=None,
     zones=None,
+    polling=True,
     tags=None,
     connection_auth=None,
     **kwargs,
@@ -118,6 +119,11 @@ async def present(
     :param zones: A list of availability zones denoting where the resource needs to come from.
 
     :param tags: A dictionary of strings can be passed as tag metadata to the storage account object.
+
+    :param polling: A boolean flag representing whether a Poller will be used during the creation of the Redis Cache.
+        If set to True, a Poller will be used by this operation and the module will not return until the Redis Cache
+        has completed its creation process and has been successfully provisioned. If set to False, the module will
+        return once the Redis Cache has successfully begun its creation process. Defaults to True.
 
     :param connection_auth: A dict with subscription and authentication parameters to be used in connecting to the
         Azure Resource Manager API.
@@ -266,6 +272,7 @@ async def present(
             static_ip=static_ip,
             zones=zones,
             tags=tags,
+            polling=polling,
             **cache_kwargs,
         )
     else:

--- a/tests/integration/states/azurerm/redis/test_redis_operations.py
+++ b/tests/integration/states/azurerm/redis/test_redis_operations.py
@@ -15,9 +15,6 @@ def sku():
     yield {"name": "Basic", "family": "C", "capacity": 2}
 
 
-@pytest.mark.skip(
-    reason="The exec and state modules need to be tweaked in order for tests to work properly"
-)
 @pytest.mark.run(order=3)
 @pytest.mark.slow
 @pytest.mark.asyncio
@@ -46,9 +43,6 @@ async def test_present(hub, ctx, resource_group, location, sku, redis_cache):
     assert ret == expected
 
 
-@pytest.mark.skip(
-    reason="The exec and state modules need to be tweaked in order for tests to work properly"
-)
 @pytest.mark.run(order=3, after="test_present", before="test_absent")
 @pytest.mark.slow
 @pytest.mark.asyncio
@@ -71,9 +65,6 @@ async def test_changes(hub, ctx, resource_group, location, sku, redis_cache):
     assert ret == expected
 
 
-@pytest.mark.skip(
-    reason="The exec and state modules need to be tweaked in order for tests to work properly"
-)
 @pytest.mark.run(order=-3)
 @pytest.mark.slow
 @pytest.mark.asyncio


### PR DESCRIPTION
### What does this PR do?
This PR adds the polling parameter to any operation that takes a long time to run, specifically vnet gateways and redis caches. Additionally, it adds in any missing wait() calls that exec modules operations use.

### Previous Behavior
Some wait() calls were missing and users of vnet gateway and redis cache states were unable to specify when they wanted the module to return.

### New Behavior
All wait() calls are accounted for and users of vnet gateway and redis cache states are able to specify when in the creation/provisioning process they want the module to return.

### Merge requirements satisfied?
- [X] Docs
- [X] Tests written/updated

### Commits signed with GPG?
Yes